### PR TITLE
Removes babel-plugin-macros from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
   },
   "devDependencies": {
     "@babel/plugin-syntax-object-rest-spread": "7.8.3",
-    "babel-plugin-macros": "^3.1.0",
     "babel-plugin-styled-components": "^2.0.7",
     "babel-plugin-twin": "^1.1.0",
     "eslint": "^8.27.0",


### PR DESCRIPTION
It's already a dependency from other packages and it'll be easy to upgrade in the future with this change