### PR TITLE
chore: fix unmet peer dependency warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "markdown-it": "^15.0.0",
     "mdast-util-to-string": "^4.0.0",
     "playwright": "^1.61.1",
+    "postcss": "^8.5.26",
     "postcss-import": "^17.0.0",
     "postcss-preset-env": "^11.3.2",
     "prism-themes": "^1.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5184,7 +5184,7 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.3.11, postcss@^8.4.47, postcss@^8.5.16, postcss@^8.5.25, postcss@^8.5.3:
+postcss@^8.3.11, postcss@^8.4.47, postcss@^8.5.16, postcss@^8.5.25, postcss@^8.5.26, postcss@^8.5.3:
   version "8.5.26"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.26.tgz#6e75135780c7e10df3433bf2266c552d35c8c620"
   integrity sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==


### PR DESCRIPTION
## Summary

Audited `yarn install` output for unmet/incorrect peer dependency warnings and cleared the ones that had a safe fix.

Went from **78 warnings → 2**.

## What changed

- Added `postcss` as an explicit `devDependency` (`^8.5.26`, the version already resolved in the tree). It's consumed directly by `postcss.config.js` via `postcss-import`/`postcss-preset-env`, but was only ever present transitively through `tailwindcss`. Yarn 1 doesn't credit a hoisted transitive install against a peer requirement, so every `postcss-preset-env`/`@csstools/*` sub-plugin flagged an unmet peer individually — that's ~76 of the 78 warnings, all one root cause. This is a no-op for what's actually installed, just makes the dependency explicit.

## What's intentionally left as-is

- `@astrojs/tailwind@6.0.2` → peer caps at `astro@^5.0.0`, we're on `astro@7.2.2`. Confirmed 6.0.2 is the latest published version (Sep 2025) — there's nothing newer to bump to. Fixing this properly means migrating to Tailwind v4 + `@tailwindcss/vite`, which is real migration work with its own regression risk, so it's tracked separately in #178 rather than bundled here.
- `@napi-rs/wasm-runtime` (missing `@emnapi/core`/`@emnapi/runtime`) → buried inside Astro's own optional WASM-fallback compiler binding (`astro > @astrojs/compiler-rs > ... > @napi-rs/wasm-runtime`). Internal to Astro's dependency tree, not actionable from this project's `package.json`.

## Verification

- `yarn install` unmet-peer warnings: 78 → 2
- `yarn build` passes end-to-end, output unchanged (Tailwind/PostCSS CSS output verified present and correctly sized, sitemap/robots/favicon pipeline untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)