### PR TITLE
ci: cache Playwright browsers to avoid repeated CDN downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,24 @@ jobs:
     - name: Install dependencies
       run: yarn install --immutable
 
+    - name: Get installed Playwright version
+      id: playwright-version
+      run: echo "version=$(node -e "console.log(require('./node_modules/playwright/package.json').version)")" >> "$GITHUB_OUTPUT"
+
+    - name: Cache Playwright browsers
+      id: playwright-cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
     - name: Install Playwright browser
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
       run: npx playwright install --with-deps chromium
+
+    - name: Install Playwright system dependencies
+      if: steps.playwright-cache.outputs.cache-hit == 'true'
+      run: npx playwright install-deps chromium
 
     - name: Build
       run: yarn build


### PR DESCRIPTION
Two consecutive CI runs on PR #180 hung for 20+ minutes on 'Install Playwright browser' with no apparent cause (no GitHub/Azure status incidents, nothing in the PR touched CI config or the Playwright version, and the identical step ran fine in 48s on the prior run) - consistent with a transient stall downloading the Chromium binary from Playwright's CDN.

Cache the ~/.cache/ms-playwright directory keyed on the resolved Playwright version, following Playwright's documented CI caching pattern. On a cache hit, skip the full install (and its CDN download) and only run 'install-deps' to install system libraries via apt, which doesn't depend on that external download.